### PR TITLE
add missing include

### DIFF
--- a/include/highfive/bits/H5Object_misc.hpp
+++ b/include/highfive/bits/H5Object_misc.hpp
@@ -11,6 +11,7 @@
 
 #include "../H5Exception.hpp"
 #include "../H5Object.hpp"
+#include <iostream>
 
 namespace HighFive {
 


### PR DESCRIPTION
Should fix this: https://travis-ci.org/chime-experiment/coco/builds/519754022
This has the same issue, but keeps a manually fixed copy: https://lwlab.dunlap.utoronto.ca:18080/blue/organizations/jenkins/kotekan/activity